### PR TITLE
Fix subscription webhooks failing with Vercel

### DIFF
--- a/src/app/api/payment/stripe/webhook/route.ts
+++ b/src/app/api/payment/stripe/webhook/route.ts
@@ -18,18 +18,7 @@ import { stripeClient } from "@/services/subscription";
 export async function POST(request: NextRequest) {
   try {
     const sig = request.headers.get("stripe-signature");
-    // const rawBody = await request.text();
     const rawBody = Buffer.from(await request.arrayBuffer());
-
-    console.log(
-      "Signing secret:",
-      JSON.stringify(process.env.STRIPE_WEBHOOK_SECRET)
-    );
-    console.log("Signature header:", sig);
-    console.log(
-      "First 200 bytes of raw body:",
-      rawBody.slice(0, 200).toString()
-    );
 
     if (!sig) {
       console.error("Missing Stripe signature header");

--- a/src/app/api/payment/stripe/webhook/route.ts
+++ b/src/app/api/payment/stripe/webhook/route.ts
@@ -18,7 +18,8 @@ import { stripeClient } from "@/services/subscription";
 export async function POST(request: NextRequest) {
   try {
     const sig = request.headers.get("stripe-signature");
-    const rawBody = await request.text();
+    // const rawBody = await request.text();
+    const rawBody = Buffer.from(await request.arrayBuffer());
 
     console.log(
       "Signing secret:",

--- a/src/app/api/payment/stripe/webhook/route.ts
+++ b/src/app/api/payment/stripe/webhook/route.ts
@@ -20,6 +20,16 @@ export async function POST(request: NextRequest) {
     const sig = request.headers.get("stripe-signature");
     const rawBody = await request.text();
 
+    console.log(
+      "Signing secret:",
+      JSON.stringify(process.env.STRIPE_WEBHOOK_SECRET)
+    );
+    console.log("Signature header:", sig);
+    console.log(
+      "First 200 bytes of raw body:",
+      rawBody.slice(0, 200).toString()
+    );
+
     if (!sig) {
       console.error("Missing Stripe signature header");
       return NextResponse.json({ error: "Missing signature" }, { status: 400 });


### PR DESCRIPTION
Replace use of request.text() as possible decoding/serialization is happening with the stripe body causing a signature mismatch.