### PR TITLE
feat: implement unread message notification indicator in ForumTabs and optimize unread message check in MessageService

### DIFF
--- a/src/components/community-forum/dm-message-card.tsx
+++ b/src/components/community-forum/dm-message-card.tsx
@@ -25,7 +25,7 @@ export function DMMessageCard({ message }: DMMessageCardProps) {
       {/* Avatar */}
       <Avatar className="h-10 w-10 flex-shrink-0">
         <AvatarFallback className={cn("text-white bg-primary")}>
-          {displayName.slice(1, 3).toUpperCase()}
+          {displayName.slice(0, 2).toUpperCase()}
         </AvatarFallback>
       </Avatar>
 

--- a/src/components/community-forum/sidebar/forum-tabs.tsx
+++ b/src/components/community-forum/sidebar/forum-tabs.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { cn } from "@/lib/utils";
+import { useHasUnreadMessages } from "@/hooks/use-forum";
 
 export interface IForumTabs {
   activePage: "Forum" | "Groups" | "Messages";
@@ -10,11 +11,13 @@ export interface IForumTabs {
 
 export function ForumTabs({ activePage, setActivePage }: IForumTabs) {
   const tabs = ["Forum", "Groups", "Messages"];
+  const { data: hasUnreadMessages } = useHasUnreadMessages();
 
   return (
     <div className="flex flex-row items-center px-1 h-9 border-b border-gray-300">
       {tabs.map((tab) => {
         const isDisabled = tab === "Messagesss";
+        const showNotification = tab === "Messages" && hasUnreadMessages;
 
         return (
           <button
@@ -26,7 +29,7 @@ export function ForumTabs({ activePage, setActivePage }: IForumTabs) {
             }}
             disabled={isDisabled}
             className={cn(
-              "flex flex-row justify-center items-center px-3 py-1 gap-2 h-9 text-sm font-medium transition-colors rounded-md",
+              "relative flex flex-row justify-center items-center px-3 py-1 gap-2 h-9 text-sm font-medium transition-colors rounded-md",
               isDisabled
                 ? "text-zinc-400 cursor-not-allowed opacity-50"
                 : "cursor-pointer",
@@ -36,6 +39,9 @@ export function ForumTabs({ activePage, setActivePage }: IForumTabs) {
             )}
           >
             {tab}
+            {showNotification && (
+              <div className="absolute top-2 right-1 h-2 w-2 bg-red-500 rounded-full border border-white"></div>
+            )}
           </button>
         );
       })}

--- a/src/hooks/use-forum.tsx
+++ b/src/hooks/use-forum.tsx
@@ -97,6 +97,8 @@ export function useDirectMessages() {
       // Invalidate unread counts
       queryClient.invalidateQueries({ queryKey: ["dm-total-unread"] });
       queryClient.invalidateQueries({ queryKey: ["dm-unread-count"] });
+      // Invalidate notification indicator
+      queryClient.invalidateQueries({ queryKey: ["has-unread-messages"] });
     },
   });
 
@@ -109,6 +111,8 @@ export function useDirectMessages() {
       // Invalidate unread counts
       queryClient.invalidateQueries({ queryKey: ["dm-total-unread"] });
       queryClient.invalidateQueries({ queryKey: ["dm-unread-count"] });
+      // Invalidate notification indicator
+      queryClient.invalidateQueries({ queryKey: ["has-unread-messages"] });
     },
   });
 
@@ -236,4 +240,18 @@ export function useSearch(searchQuery?: string) {
     isLoading: peopleQuery.isLoading || messagesQuery.isLoading,
     error: peopleQuery.error || messagesQuery.error,
   };
+}
+
+/**
+ * Hook to check if user has unread messages (optimized for performance)
+ */
+export function useHasUnreadMessages() {
+  return useQuery({
+    queryKey: ["has-unread-messages"],
+    queryFn: () => messageService.hasUnreadMessages(),
+    staleTime: 10 * 1000, // 10 seconds
+    refetchInterval: 15 * 1000, // Refetch every 15 seconds for real-time updates
+    refetchIntervalInBackground: true, // Keep refetching even when tab is not active
+    refetchOnWindowFocus: true, // Refetch when user comes back to tab
+  });
 }

--- a/src/services/forum/message-service.ts
+++ b/src/services/forum/message-service.ts
@@ -200,6 +200,33 @@ export class MessageService extends BaseForumService {
   }
 
   /**
+   * Verifica se há mensagens não lidas (mais performático que contar)
+   */
+  async hasUnreadMessages(): Promise<boolean> {
+    try {
+      const profile = await this.requireProfile();
+
+      const { data, error } = await this.supabase
+        .from("messages")
+        .select("id")
+        .eq("receiver_anon_id", profile.id)
+        .is("seen_at", null)
+        .eq("status", "approved")
+        .limit(1)
+        .single();
+
+      if (error && error.code !== "PGRST116") {
+        this.handleError(error, "check unread messages");
+      }
+
+      return !!data;
+    } catch (error) {
+      this.handleError(error, "check unread messages");
+      return false;
+    }
+  }
+
+  /**
    * Deleta uma mensagem (apenas o remetente pode deletar)
    */
   async deleteMessage(messageId: string): Promise<void> {


### PR DESCRIPTION

### PR Description

This PR introduces a real-time unread message notification indicator in the community forum’s navigation tabs and optimizes the backend logic for checking unread messages:

#### Key Features

- **Unread Message Notification in ForumTabs**
  - Adds a red dot indicator to the "Messages" tab in the forum navigation when the user has unread direct messages.
  - The indicator updates in real time, with efficient polling and cache invalidation for a responsive user experience.

- **Optimized Unread Message Check in MessageService**
  - Introduces a new `hasUnreadMessages()` method in `MessageService` that performs a highly efficient check (using `limit(1)` and returning a boolean) instead of counting all unread messages.
  - Reduces database load and improves performance, especially for users with a large number of messages.

- **New React Hook: useHasUnreadMessages**
  - Provides a performant, auto-refreshing hook for components to check if there are unread messages.
  - Uses `react-query` with a 10s stale time and 15s refetch interval, including background and window focus updates.

- **Automatic Cache Invalidation**
  - Ensures the notification indicator is always up-to-date by invalidating the relevant query cache when messages are sent or marked as read.