### PR TITLE
feat: implement coach profile loading and details pages with extended bio

### DIFF
--- a/src/app/(protected)/coaching/[id]/loading.tsx
+++ b/src/app/(protected)/coaching/[id]/loading.tsx
@@ -1,0 +1,56 @@
+import { Breadcrumb } from "@/components/layout/header";
+import PageTemplate from "@/components/layout/page-template";
+import React from "react";
+import { sidebarIcons } from "@/components/layout/nav/app-sidebar";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function CoachProfileLoading() {
+  const breadcrumbs: Breadcrumb[] = [
+    { label: "Coaching", href: "/coaching" },
+    { label: "Loading..." },
+  ];
+
+  return (
+    <PageTemplate
+      breadcrumbs={breadcrumbs}
+      headerIcon={sidebarIcons.coachingProgram}
+    >
+      <div className="max-w-4xl mx-auto mt-10">
+        {/* Header with coach info */}
+        <div className="flex flex-col md:flex-row gap-6 mb-8 items-center md:items-start">
+          <Skeleton className="w-32 h-32 rounded-full flex-shrink-0" />
+          <div className="w-full">
+            <Skeleton className="h-10 w-3/4 mb-4" />
+            <Skeleton className="h-4 w-full mb-2" />
+            <Skeleton className="h-4 w-full mb-2" />
+            <Skeleton className="h-4 w-3/4 mb-4" />
+
+            <div className="flex flex-col sm:flex-row gap-4 mt-4">
+              <Skeleton className="h-6 w-40" />
+              <Skeleton className="h-6 w-40" />
+            </div>
+
+            <div className="mt-6">
+              <Skeleton className="h-10 w-40" />
+            </div>
+          </div>
+        </div>
+
+        {/* Extended bio skeleton */}
+        <div className="mt-8">
+          <Skeleton className="h-8 w-48 mb-6" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-3/4 mb-4" />
+
+          <Skeleton className="h-6 w-64 mb-4 mt-6" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-1/2 mb-4" />
+        </div>
+      </div>
+    </PageTemplate>
+  );
+}

--- a/src/app/(protected)/coaching/[id]/page.tsx
+++ b/src/app/(protected)/coaching/[id]/page.tsx
@@ -13,11 +13,11 @@ import { CalendarHeart, ChevronLeft, HeartHandshake } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 
 interface ICoachProfilePage {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 export default async function CoachProfilePage({ params }: ICoachProfilePage) {
-  const { id } = params;
+  const { id } = await params;
 
   if (!id) {
     notFound();

--- a/src/app/(protected)/coaching/[id]/page.tsx
+++ b/src/app/(protected)/coaching/[id]/page.tsx
@@ -1,0 +1,141 @@
+import { Breadcrumb } from "@/components/layout/header";
+import PageTemplate from "@/components/layout/page-template";
+import React from "react";
+import { sidebarIcons } from "@/components/layout/nav/app-sidebar";
+import { notFound } from "next/navigation";
+import { serverFetch } from "@/utils/fetch";
+import { Coach } from "@/typing/strapi";
+import { ExtendedBioRenderer } from "@/components/coaching/extended-bio-renderer";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { CalendarHeart, ChevronLeft, HeartHandshake } from "lucide-react";
+import { Separator } from "@/components/ui/separator";
+
+interface ICoachProfilePage {
+  params: { id: string };
+}
+
+export default async function CoachProfilePage({ params }: ICoachProfilePage) {
+  const { id } = params;
+
+  if (!id) {
+    notFound();
+  }
+
+  try {
+    const data: { data?: Coach } = await serverFetch(
+      `/api/coaches/${id}/details`
+    );
+    const coach = data.data;
+
+    if (!coach) {
+      notFound();
+    }
+
+    const breadcrumbs: Breadcrumb[] = [
+      { label: "Coaching", href: "/coaching" },
+      { label: coach.name || "" },
+    ];
+
+    return (
+      <PageTemplate
+        breadcrumbs={breadcrumbs}
+        headerIcon={sidebarIcons.coachingProgram}
+      >
+        <div className="max-w-4xl mx-auto mt-10">
+          <Link
+            href="/coaching"
+            className="inline-flex items-center text-sm text-muted-foreground hover:text-primary transition-colors mb-6"
+          >
+            <ChevronLeft className="mr-1 h-4 w-4" />
+            Back to Coaches
+          </Link>
+
+          {/* Header with coach info */}
+          <div className="flex flex-col md:flex-row gap-6 mb-8 items-center md:items-start mt-6">
+            {coach.avatar && (
+              <div className="w-32 h-32 overflow-hidden rounded-full flex-shrink-0">
+                <Image
+                  src={coach.avatar.url}
+                  className="object-cover w-full h-full"
+                  alt={coach.name}
+                  width={128}
+                  height={128}
+                />
+              </div>
+            )}
+            <div>
+              <h1 className="text-3xl font-bold text-center md:text-left">
+                {coach.name}
+              </h1>
+              <p className="text-gray-600 mt-2 text-center md:text-left">
+                {coach.summary}
+              </p>
+
+              <div className="flex flex-col sm:flex-row gap-4 mt-4">
+                <div className="flex items-center gap-2">
+                  <HeartHandshake className="size-5 text-primary" />
+                  <span>{coach.focus_areas.join(", ")}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <CalendarHeart className="size-5 text-primary" />
+                  <span>{coach.experience_in_years}+ years experience</span>
+                </div>
+              </div>
+
+              <div className="mt-6">
+                <Link href={coach.booking_url} target="_blank" rel="noreferrer">
+                  <Button>Book a session</Button>
+                </Link>
+              </div>
+            </div>
+          </div>
+
+          <Separator />
+
+          {/* Extended bio */}
+          {coach.extended_bio && (
+            <div className="mt-8 prose dark:prose-invert max-w-none">
+              <h2 className="text-2xl font-semibold mb-4">
+                About {coach.name.split(" ")[0]}
+              </h2>
+              <ExtendedBioRenderer blocks={coach.extended_bio} />
+            </div>
+          )}
+        </div>
+      </PageTemplate>
+    );
+  } catch (error) {
+    console.error("Error fetching coach profile:", error);
+    return (
+      <PageTemplate
+        breadcrumbs={[{ label: "Coaching", href: "/coaching" }]}
+        headerIcon={sidebarIcons.coachingProgram}
+      >
+        <div className="py-10">
+          <Link
+            href="/coaching"
+            className="inline-flex items-center text-sm text-muted-foreground hover:text-primary transition-colors mb-6"
+          >
+            <ChevronLeft className="mr-1 h-4 w-4" />
+            Back to Coaches
+          </Link>
+
+          <div className="text-center">
+            <h2 className="text-2xl font-bold mb-4">
+              Unable to load coach profile
+            </h2>
+            <p className="mb-6">
+              There was an error loading this coach&apos;s profile. Please try
+              again later.
+            </p>
+            <Link href="/coaching">
+              <Button>Return to Coaches</Button>
+            </Link>
+          </div>
+        </div>
+      </PageTemplate>
+    );
+  }
+}

--- a/src/app/api/coaches/[id]/details/route.ts
+++ b/src/app/api/coaches/[id]/details/route.ts
@@ -4,7 +4,7 @@ import { API_CONFIG } from "@/utils/constants";
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     getAuthenticatedUser(request);
@@ -12,7 +12,7 @@ export async function GET(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { id } = params;
+  const { id } = await params;
 
   if (!id) {
     return NextResponse.json(

--- a/src/app/api/coaches/[id]/details/route.ts
+++ b/src/app/api/coaches/[id]/details/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthenticatedUser } from "@/utils/supabase/auth";
+import { API_CONFIG } from "@/utils/constants";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    getAuthenticatedUser(request);
+  } catch {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = params;
+
+  if (!id) {
+    return NextResponse.json(
+      { error: "Coach ID is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const strapiUrl =
+      process.env.NEXT_PUBLIC_STRAPI_URL || API_CONFIG.STRAPI_URL;
+    const strapiToken =
+      process.env.STRAPI_API_TOKEN || API_CONFIG.STRAPI_API_KEY;
+
+    if (!strapiUrl || !strapiToken) {
+      console.error("Missing Strapi configuration");
+      return NextResponse.json(
+        { error: "Internal server error" },
+        { status: 500 }
+      );
+    }
+
+    const response = await fetch(`${strapiUrl}/api/coaches/${id}/details`, {
+      headers: {
+        Authorization: `Bearer ${strapiToken}`,
+      },
+      next: { revalidate: 60 }, // Cache for 60 seconds
+    });
+
+    if (!response.ok) {
+      throw new Error(`Error fetching coach details: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error("Error in coach details API route:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch coach details" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/coaching/coach-card.tsx
+++ b/src/components/coaching/coach-card.tsx
@@ -47,6 +47,9 @@ export function CoachCard({ coach, className }: ICoachCard) {
         <p> {coach.summary} </p>
       </CardContent>
       <CardFooter className="flex gap-4 justify-center">
+        <Link href={`/coaching/${coach.id}`}>
+          <Button variant="outline">View Profile</Button>
+        </Link>
         <Link href={coach.booking_url} target="_blank" rel="noreferrer">
           <Button>Book a session</Button>
         </Link>

--- a/src/components/coaching/extended-bio-renderer.tsx
+++ b/src/components/coaching/extended-bio-renderer.tsx
@@ -1,0 +1,70 @@
+import React, { JSX } from "react";
+import { ExtendedBioBlock } from "@/typing/strapi";
+
+interface IExtendedBioRenderer {
+  blocks: ExtendedBioBlock[];
+}
+
+export function ExtendedBioRenderer({ blocks }: IExtendedBioRenderer) {
+  if (!blocks || blocks.length === 0) {
+    return null;
+  }
+
+  const renderBlock = (block: ExtendedBioBlock, index: number) => {
+    switch (block.type) {
+      case "paragraph":
+        return (
+          <p key={index} className="mb-4">
+            {block.children.map((child, childIndex) => (
+              <span
+                key={childIndex}
+                className={`
+                  ${child.bold ? "font-bold" : ""}
+                  ${child.italic ? "italic" : ""}
+                `}
+              >
+                {child.text}
+              </span>
+            ))}
+          </p>
+        );
+
+      case "heading":
+        const HeadingTag =
+          `h${block.level || 2}` as keyof JSX.IntrinsicElements;
+        return (
+          <HeadingTag key={index} className="font-bold mb-3 mt-6">
+            {block.children.map((child) => child.text).join("")}
+          </HeadingTag>
+        );
+
+      case "list":
+        return (
+          <ul key={index} className="list-disc list-inside mb-4">
+            {block.children.map((child, childIndex) => (
+              <li key={childIndex}>{child.text}</li>
+            ))}
+          </ul>
+        );
+
+      case "quote":
+        return (
+          <blockquote
+            key={index}
+            className="border-l-4 border-gray-300 pl-4 italic mb-4"
+          >
+            {block.children.map((child) => child.text).join("")}
+          </blockquote>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="extended-bio prose dark:prose-invert max-w-none">
+      {blocks.map((block, index) => renderBlock(block, index))}
+    </div>
+  );
+}

--- a/src/typing/strapi.ts
+++ b/src/typing/strapi.ts
@@ -55,6 +55,17 @@ export type Article = {
   body: BlocksContent;
 };
 
+export interface ExtendedBioBlock {
+  type: "paragraph" | "heading" | "list" | "quote";
+  children: Array<{
+    type: "text";
+    text: string;
+    bold?: boolean;
+    italic?: boolean;
+  }>;
+  level?: number; // For headings
+}
+
 export type Coach = {
   id: number;
   name: string;
@@ -63,6 +74,7 @@ export type Coach = {
   booking_url: string;
   experience_in_years: number;
   avatar?: Image;
+  extended_bio?: ExtendedBioBlock[];
 };
 
 export type SubscriptionPlanStatus = "DRAFT" | "ACTIVE" | "RETIRED";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -13,3 +13,8 @@ export const PUBLIC_PATHS: { path: string; exact?: boolean }[] = [
 ];
 
 export const FREE_TRIAL_DAYS = 21;
+
+export const API_CONFIG = {
+  STRAPI_URL: process.env.NEXT_PUBLIC_STRAPI_URL || "http://localhost:1337",
+  STRAPI_API_KEY: process.env.STRAPI_API_TOKEN,
+};


### PR DESCRIPTION
- Added `loading.tsx` for displaying a skeleton loader while fetching coach profile data.
- Created `page.tsx` to render the coach profile, including details such as name, summary, experience, and a link to book a session.
- Introduced `route.ts` for the API endpoint to fetch coach details securely.
- Developed `extended-bio-renderer.tsx` to render the coach's extended bio with various block types.
- Updated `coach-card.tsx` to include a link for viewing individual coach profiles.
- Enhanced `strapi.ts` to define the structure for extended bio blocks.

These changes enhance the user experience by providing a seamless loading state and detailed coach information.